### PR TITLE
Fix/entry point

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,125 @@
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
 .coverage
-*.egg-info
+.coverage.*
 .cache
-__pycache__
-*.pyc
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+.static_storage/
+.media/
+local_settings.py
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+
+# pytest
+.pytest_cache/
+
+### VirtualEnv template
+# Virtualenv
+# http://iamzed.com/2009/05/07/a-primer-on-virtualenv/
+[Bb]in
+[Ii]nclude
+[Ll]ib
+[Ll]ib64
+[Ll]ocal
+[Ss]cripts
+pyvenv.cfg
+pip-selfcheck.json
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+.idea/

--- a/README.md
+++ b/README.md
@@ -9,24 +9,24 @@ Python client for the `legifrance.gouv.fr` website.
 CLI usage
 ---------
 
-The command-line script `legipy-cli.py` gives access to service commands from the command line and outputs data in JSON format.
+The command-line script `legipy` gives access to service commands from the command line and outputs data in JSON format.
 
 ### List legislatures
 
-`legipy-cli.py legislatures`
+`legipy legislatures`
 
 ### List published laws
 
-`legipy-cli.py published_laws [--legislature=CURRENT]`
+`legipy published_laws [--legislature=CURRENT]`
 
 ### List pending law projects
 
-`legipy-cli.py law_projects [--legislature=CURRENT]`
+`legipy law_projects [--legislature=CURRENT]`
 
 ### List pending law proposals
 
-`legipy-cli.py law_proposals [--legislature=CURRENT]`
+`legipy law_proposals [--legislature=CURRENT]`
 
 ### Show specific law
 
-`legipy-cli.py law JORFDOLE000024106525`
+`legipy law JORFDOLE000024106525`

--- a/legipy/__main__.py
+++ b/legipy/__main__.py
@@ -1,0 +1,13 @@
+# coding: utf-8
+"""
+Main entry point
+
+See:
+
+- https://docs.python.org/3/library/__main__.html
+
+"""
+from legipy.cli import cli
+
+if __name__ == "__main__":
+    cli()

--- a/legipy/cli.py
+++ b/legipy/cli.py
@@ -2,9 +2,10 @@
 # coding: utf-8
 from __future__ import print_function
 
-import click
 import json
 import sys
+
+import click
 
 from legipy.services import LawService, LegislatureService
 
@@ -24,32 +25,32 @@ def _dump_items(ary):
 
 
 @click.group()
-def cli():
+def cli(short_help="Client for the `legifrance.gouv.fr` website."):
     pass
 
 
-@cli.command()
+@cli.command(short_help="List published laws")
 @click.option('--legislature', default=current_legislature(),
               help='Legislature number')
 def published_laws(legislature):
     _dump_items(LawService().published_laws(legislature))
 
 
-@cli.command()
+@cli.command(short_help="List pending law projects")
 @click.option('--legislature', default=current_legislature(),
               help='Legislature number')
 def law_projects(legislature):
     _dump_items(LawService().pending_laws(legislature, True))
 
 
-@cli.command()
+@cli.command(short_help="List pending law proposals")
 @click.option('--legislature', default=current_legislature(),
               help='Legislature number')
 def law_proposals(legislature):
     _dump_items(LawService().pending_laws(legislature, False))
 
 
-@cli.command()
+@cli.command(short_help="Show specific law")
 @click.argument('legi_id')
 def law(legi_id):
     service = LawService()
@@ -62,7 +63,7 @@ def law(legi_id):
     _dump_item(law)
 
 
-@cli.command()
+@cli.command(short_help="List legislatures")
 def legislatures():
     _dump_items(LegislatureService().legislatures())
 

--- a/setup.py
+++ b/setup.py
@@ -42,14 +42,28 @@ setup(
     ],
 
     install_requires=[
-        'beautifulsoup4',
-        'click',
-        'html5lib',
-        'requests',
-        'urllib3[secure]'
+        'beautifulsoup4 < 4.7, >= 4.6',
+        'click < 6.8, >= 6.7',
+        'html5lib < 1.1, >= 1.0',
+        'requests < 2.19, >= 2.18',
+        'urllib3[secure] <1.23, >= 1.22',
+        # 'six < 1.12, >= 1.11',
     ],
 
-    scripts=[
-        'bin/legipy-cli.py'
-    ],
+    # http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies
+    extras_require={
+        'test':
+            [
+                'coverage < 4.5, >= 4.4',
+                'pytest < 3.5, >= 3.4',
+                'pytest-cov < 2.6, >= 2.5',
+                'vcrpy < 1.12, >= 1.11',  # vcr
+            ]
+    },
+
+    entry_points={
+        'console_scripts': [
+            'legipy = legipy.__main__:cli'
+        ]
+    },
 )


### PR DESCRIPTION
Hi,

This is a **bug fix**.

In under to work under Windows, the Python script `legipy-cli.py` must be turned into an [entry point](http://setuptools.readthedocs.io/en/latest/setuptools.html#automatic-script-creation). This is a *best practice*. The cli should also be part of the `legipy` package.

This PR also improve the .gitignore (see: #1) and add documentation to the CLI.
