### PR TITLE
Fix/py27 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - 3.4
   - 3.5
   - 3.6
-  - 3.7
+  - 3.7-dev
 
 install:
   - pip install -U setuptools>=18.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 language: python
 
 python:
+  - 2.7
+  - 3.4
   - 3.5
+  - 3.6
+  - 3.7
 
 install:
-  - pip install pytest pytest-cov flake8 pep8 vcrpy
   - pip install -U setuptools>=18.5
+  - pip install pytest pytest-cov flake8 pep8 vcrpy
   - pip install -e .
 
 script:

--- a/legipy/common.py
+++ b/legipy/common.py
@@ -45,7 +45,7 @@ def page_url(page):
 
 
 def cleanup_url(url):
-    return re.sub(r';jsessionid=[^\?]+\?', '?', url)
+    return re.sub(r';jsessionid=[^?]+\?', '?', url)
 
 
 def merge_spaces(string):
@@ -60,7 +60,8 @@ def parse_date(string):
 
     try:
         month = 1 + MONTHS.index(match.group(2))
-    except:
+    except ValueError:
+        # not in list
         return None
 
     return datetime.date(int(match.group(3)), month, int(match.group(1)))

--- a/legipy/common.py
+++ b/legipy/common.py
@@ -1,23 +1,22 @@
 # coding: utf-8
 
-from datetime import date
 import re
-
+import datetime
 
 DOMAIN = 'www.legifrance.gouv.fr'
 
 MONTHS = [
-    'janvier',
+    u'janvier',
     u'février',
-    'mars',
-    'avril',
-    'mai',
-    'juin',
-    'juillet',
+    u'mars',
+    u'avril',
+    u'mai',
+    u'juin',
+    u'juillet',
     u'août',
-    'septembre',
-    'octobre',
-    'novembre',
+    u'septembre',
+    u'octobre',
+    u'novembre',
     u'décembre'
 ]
 
@@ -64,7 +63,7 @@ def parse_date(string):
     except:
         return None
 
-    return date(int(match.group(3)), month, int(match.group(1)))
+    return datetime.date(int(match.group(3)), month, int(match.group(1)))
 
 
 def parse_roman(string):
@@ -77,7 +76,7 @@ def parse_roman(string):
 
     for index in range(len(string)):
         value = ROMAN_VALUES[string[index]]
-        if index < len(string) - 1 and ROMAN_VALUES[string[index+1]] > value:
+        if index < len(string) - 1 and ROMAN_VALUES[string[index + 1]] > value:
             total -= value
         else:
             total += value

--- a/legipy/models/base.py
+++ b/legipy/models/base.py
@@ -3,7 +3,7 @@
 from datetime import date
 
 
-class LegipyModel:
+class LegipyModel(object):
     def to_json(self):
         d = dict()
 

--- a/legipy/parsers/law_parser.py
+++ b/legipy/parsers/law_parser.py
@@ -38,7 +38,8 @@ def parse_law(url, html, id_legi):
         try:
             LAW_KINDS.index(prop.group(2))
             law.kind = prop.group(2)
-        except:
+        except ValueError:
+            # not in list
             law.kind = None
 
     if title_remain:
@@ -56,7 +57,7 @@ def parse_law(url, html, id_legi):
         law.id_senat = re.search(r'([^/]+)\.html$', law.url_senat).group(1)
 
     dos_an = soup.find(lambda e: e.name == 'a' and
-                                 re.search(r'/dossiers/', e['href']))
+                       re.search(r'/dossiers/', e['href']))
 
     if dos_an:
         law.url_an = dos_an['href'].split('#')[0]

--- a/legipy/parsers/law_parser.py
+++ b/legipy/parsers/law_parser.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import unicode_literals
 
 from bs4 import BeautifulSoup
 import re
@@ -48,19 +49,19 @@ def parse_law(url, html, id_legi):
             law.pub_date = parse_date(pub_date.group(1))
 
     dos_senat = soup.find(lambda e: e.name == 'a' and (
-                    re.search(r'/dossier-legislatif/', e['href']) or
-                    re.search(r'/dossierleg/', e['href'])))
+            re.search(r'/dossier-legislatif/', e['href']) or
+            re.search(r'/dossierleg/', e['href'])))
     if dos_senat:
         law.url_senat = dos_senat['href'].split('#')[0]
         law.id_senat = re.search(r'([^/]+)\.html$', law.url_senat).group(1)
 
     dos_an = soup.find(lambda e: e.name == 'a' and
-                       re.search(r'/dossiers/', e['href']))
+                                 re.search(r'/dossiers/', e['href']))
 
     if dos_an:
         law.url_an = dos_an['href'].split('#')[0]
         law.legislature = int(re.search(r'/(\d+)/dossiers/',
-                              law.url_an).group(1))
+                                        law.url_an).group(1))
         law.id_an = re.search(r'([^/]+)\.asp$', law.url_an).group(1)
 
     return law

--- a/legipy/parsers/legislature_list_parser.py
+++ b/legipy/parsers/legislature_list_parser.py
@@ -20,6 +20,9 @@ def parse_legislature_list(url, html):
         if m:
             start = parse_date(m.group(1))
             end = None
+        else:
+            start = None
+            end = None
 
         m = re.search(r'du (\d{1,2}(?:er)?\s+[^\s]+\s+\d{4}) '
                       r'au (\d{1,2}(?:er)?\s+[^\s]+\s+\d{4})', text)

--- a/legipy/parsers/legislature_list_parser.py
+++ b/legipy/parsers/legislature_list_parser.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import unicode_literals
 
 from bs4 import BeautifulSoup
 import re

--- a/legipy/parsers/pending_law_list_parser.py
+++ b/legipy/parsers/pending_law_list_parser.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+from __future__ import unicode_literals
 
 from bs4 import BeautifulSoup
 import re

--- a/legipy/parsers/pending_law_list_parser.py
+++ b/legipy/parsers/pending_law_list_parser.py
@@ -2,7 +2,8 @@
 
 from bs4 import BeautifulSoup
 import re
-from urllib.parse import urljoin, urlparse, parse_qs
+
+from six.moves.urllib.parse import urljoin, urlparse, parse_qs
 
 from ..common import cleanup_url, merge_spaces
 from ..models import Law

--- a/legipy/parsers/published_law_list_parser.py
+++ b/legipy/parsers/published_law_list_parser.py
@@ -1,8 +1,10 @@
 # coding: utf-8
 
-from bs4 import BeautifulSoup
 import re
-from urllib.parse import urljoin, urlparse, parse_qs
+
+from six.moves.urllib.parse import urljoin, urlparse, parse_qs
+
+from bs4 import BeautifulSoup
 
 from ..common import cleanup_url, merge_spaces, parse_date
 from ..models import Law

--- a/legipy/parsers/published_law_list_parser.py
+++ b/legipy/parsers/published_law_list_parser.py
@@ -1,10 +1,10 @@
 # coding: utf-8
+from __future__ import unicode_literals
 
 import re
 
-from six.moves.urllib.parse import urljoin, urlparse, parse_qs
-
 from bs4 import BeautifulSoup
+from six.moves.urllib.parse import urljoin, urlparse, parse_qs
 
 from ..common import cleanup_url, merge_spaces, parse_date
 from ..models import Law

--- a/legipy/services/law_service.py
+++ b/legipy/services/law_service.py
@@ -7,7 +7,7 @@ from ..parsers import (parse_pending_law_list, parse_published_law_list,
                        parse_law)
 
 
-class LawService:
+class LawService(object):
     pub_url = servlet_url('affichLoiPubliee')
     pend_url = servlet_url('affichLoiPreparation')
 

--- a/legipy/services/legislature_service.py
+++ b/legipy/services/legislature_service.py
@@ -6,7 +6,7 @@ from ..common import page_url
 from ..parsers import parse_legislature_list
 
 
-class LegislatureService:
+class LegislatureService(object):
     url = page_url('dossiers_legislatifs')
     cache = None
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,3 @@
 [pytest]
+; .. warning:: comment this line to allow breakpoints to work on PyCharm
 addopts = --cov=legipy

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,14 @@ setup(
     include_package_data=True,
 
     classifiers=[
-        'Development Status :: 1 - Planning',
+        'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     keywords='scraping politics data france',

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,9 @@ setup(
         'Development Status :: 4 - Beta',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
     ],
 
     keywords='scraping politics data france',

--- a/tests/test_legislature_service.py
+++ b/tests/test_legislature_service.py
@@ -6,8 +6,8 @@ import vcr
 
 from legipy.services import LegislatureService
 
-
 recorder = vcr.VCR(cassette_library_dir='tests/fixtures/cassettes')
+
 
 @recorder.use_cassette()
 def test_list_legislatures():

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27, py34, py35, py36, py37
+
+[testenv]
+commands = pytest
+deps =
+    coverage < 4.5, >= 4.4
+    pytest < 3.5, >= 3.4
+    pytest-cov < 2.6, >= 2.5
+    vcrpy < 1.12, >= 1.11


### PR DESCRIPTION
Hi,

This is a **minor improvement**.

- Change Travis CI configuration file to run build on py27, py34, py35, py36, py37.
- Use the `from __future__ import unicode_literals` directive to have Python 2 + 3 compatible RegEx (unicode raw string).
- Convert code for py27 support, using the [six](https://pythonhosted.org/six/). library.
- Minor change in the project configuration: change the development status to 'Development Status :: 4 - Beta', add the classifiers for Py34, Py35, Py36 and Py37.

Regards,
– Laurent LAPORTE
